### PR TITLE
Enhance patch warning message with firmware details

### DIFF
--- a/Localization/Localizable.xcstrings
+++ b/Localization/Localizable.xcstrings
@@ -15225,7 +15225,7 @@
         }
       }
     },
-    "The patch is intended to be used for only 3 days and 8 hours. Exceeding this time may cause the patch to become unreliable. This is NOT recommended. Consider using normal lifetime." : {
+    "The patch is intended to be used for only 3 days and 8 hours. Exceeding this time may cause the patch to become unreliable. This is NOT recommended. Consider using normal lifetime. Please be aware that new firmware in the latest generation of pump bases may block bolus commands after 5 days (120 hours)." : {
       "comment" : "warning body",
       "extractionState" : "manual",
       "localizations" : {
@@ -15256,7 +15256,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "The patch is intended to be used for only 3 days and 8 hours. Exceeding this time may cause the patch to become unreliable. This is NOT recommended. Consider using normal lifetime."
+            "value" : "The patch is intended to be used for only 3 days and 8 hours. Exceeding this time may cause the patch to become unreliable. This is NOT recommended. Consider using normal lifetime. Please be aware that new firmware in the latest generation of pump bases may block bolus commands after 5 days (120 hours)."
           }
         },
         "es" : {


### PR DESCRIPTION
Updated warning message to include information about new firmware affecting bolus commands after 5 days.

Note: as discussed in PR #21, moved change from driver to localization file for primary string and english translation.
Hope this is the right way to do it. 