### PR TITLE
tweaks for patch deactivation

### DIFF
--- a/MedtrumKit/PumpManager/BluetoothManager.swift
+++ b/MedtrumKit/PumpManager/BluetoothManager.swift
@@ -70,9 +70,6 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
     }
 
     func ensureConnected(_ completionAsync: @escaping (MedtrumConnectError?) async -> Void) {
-        // Reset force disconnect
-        forcedDisconnect = false
-
         guard connectCompletion == nil else {
             logger.error("EnsureConnected is already running...")
             Task {
@@ -122,6 +119,7 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
 
         // We are disconnected and have no reference to the previous connection
         // Start to scan for patch and reconnect the long way
+        startTimeout(seconds: .seconds(15))
         startScan { result in
             switch result {
             case let .failure(error):
@@ -155,6 +153,11 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
                 }
 
                 self.logger.error("Failed to connect: Timeout reached...")
+
+                if self.manager.isScanning {
+                    self.manager.stopScan()
+                    self.scanCompletion = nil
+                }
 
                 connectionCallback(.failedToConnectToDevice)
                 self.connectCompletion = nil
@@ -282,6 +285,7 @@ extension BluetoothManager {
         }
 
         connectionTimeout?.cancel()
+        forcedDisconnect = false
 
         self.peripheral = peripheral
         peripheralManager = PeripheralManager(peripheral, self, pumpManager, completion)
@@ -310,6 +314,11 @@ extension BluetoothManager {
                 "Device disconnected, name: \(peripheral.name ?? "<NO_NAME>"), error: \(error?.localizedDescription ?? "No error")"
             )
 
+        if forcedDisconnect {
+            forcedDisconnect = false
+            return
+        }
+
         if let pumpManager = self.pumpManager {
             pumpManager.state.isConnected = false
             pumpManager.notifyStateDidChange()
@@ -324,7 +333,7 @@ extension BluetoothManager {
             connectCompletion(.failedToConnectToDevice)
             self.connectCompletion = nil
 
-        } else if !forcedDisconnect {
+        } else {
             ensureConnected { error in
                 if let error = error {
                     self.logger.warning("Failed to auto-reconnect: \(error)")

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -222,7 +222,7 @@ public extension MedtrumPumpManager {
             return
         #endif
 
-        bluetooth.ensureConnected { error in
+        ensureConnectedAndActive { error in
             if let error = error {
                 self.log.error("Failed to connect: \(error.localizedDescription)")
                 completion?(nil)
@@ -314,7 +314,7 @@ public extension MedtrumPumpManager {
         let duration = estimatedDuration(toBolus: units)
         log.info("Enact bolus - \(units)U, \(duration)sec")
 
-        bluetooth.ensureConnected { error in
+        ensureConnectedAndActive { error in
             if let error = error {
                 self.log.error("Failed to connect: \(error.localizedDescription)")
                 self.resetBolusState()
@@ -386,7 +386,7 @@ public extension MedtrumPumpManager {
         state.bolusState = .canceling
         notifyStateDidChange()
 
-        bluetooth.ensureConnected { error in
+        ensureConnectedAndActive { error in
             if let error = error {
                 self.log.error("Failed to connect: \(error.localizedDescription)")
                 self.state.bolusState = oldBolusState
@@ -458,7 +458,7 @@ public extension MedtrumPumpManager {
             return
         }
 
-        bluetooth.ensureConnected { error in
+        ensureConnectedAndActive { error in
             if let error = error {
                 self.log.error("Failed to connect: \(error.localizedDescription)")
                 completion(.communication(error))
@@ -581,7 +581,7 @@ public extension MedtrumPumpManager {
     func suspendPatch(duration: TimeInterval, completion: @escaping ((any Error)?) -> Void) {
         log.info("Suspending delivery...")
 
-        bluetooth.ensureConnected { error in
+        ensureConnectedAndActive { error in
             if let error = error {
                 self.log.error("Failed to connect: \(error.localizedDescription)")
                 completion(error)
@@ -632,7 +632,7 @@ public extension MedtrumPumpManager {
     func resumeDelivery(completion: @escaping ((any Error)?) -> Void) {
         log.info("Suspending delivery...")
 
-        bluetooth.ensureConnected { error in
+        ensureConnectedAndActive { error in
             if let error = error {
                 self.log.error("Failed to connect: \(error.localizedDescription)")
                 completion(error)
@@ -698,7 +698,7 @@ public extension MedtrumPumpManager {
             return
         }
 
-        bluetooth.ensureConnected { error in
+        ensureConnectedAndActive { error in
             if let error = error {
                 self.log.error("Failed to connect: \(error.localizedDescription)")
                 completion(.failure(error))
@@ -992,7 +992,7 @@ public extension MedtrumPumpManager {
     func clearAlert(alertType: AlertType, completion: @escaping (Bool) -> Void) {
         log.info("Clearing alert - alertType: \(alertType.rawValue)")
 
-        bluetooth.ensureConnected { error in
+        ensureConnectedAndActive { error in
             if let error = error {
                 self.log.error("Failed to connect to pump: \(error)")
                 completion(false)
@@ -1025,7 +1025,7 @@ public extension MedtrumPumpManager {
     func updatePatchSettings(completion: @escaping (MedtrumUpdatePatchResult) -> Void) {
         log.info("Update patch settings...")
 
-        bluetooth.ensureConnected { error in
+        ensureConnectedAndActive { error in
             if let error = error {
                 self.log.error("Failed to connect to pump: \(error)")
                 completion(.failure(error: .connectionFailure))
@@ -1181,6 +1181,15 @@ public extension MedtrumPumpManager {
                 }
             }
         }
+    }
+
+    private func ensureConnectedAndActive(_ completionAsync: @escaping (MedtrumConnectError?) async -> Void) {
+        guard state.pumpState.rawValue >= PatchState.active.rawValue else {
+            log.warning("No active patch, failing immediately")
+            Task { await completionAsync(.failedToFindDevice) }
+            return
+        }
+        bluetooth.ensureConnected(completionAsync)
     }
 
     private func handlePumpDelegateError(method: String, _ error: Error, _ function: String = #function, _ line: Int = #line) {


### PR DESCRIPTION
Trying to fix the priming failure (first attempt) - follow up to @bastiaanv original PR:

* move the `forcedDisconnect = false` from `ensureConnected` into the `centralManager ... didDisconnectPeripheral` callback 
* also reset the flag to `false` inside `centralManager ... didConnect` (in case the `didDisconnectPeripheral` never happens?)

Another, semi-related, issue:
* after I deactivated the patch and before I activated a new one (and after restarting iAPS)
* iAPS sent a command to the pump manager
* the pump manager never completed the callback (neither successful or failure) -> infinite loop spinner
* the fix is to introduce the `private func ensureConnectedAndActive` wrapper in the `MedtrumPumpManager`
* this wrapper delegates to the `bluetooth.ensureConnected` but first checks if the patch is active, and fails immediately if not
* this wrapper is used instead of `bluetooth.ensureConnected` in all command-related call sites
* `bluetooth.ensureConnected` is still used for priming/activation/deactivation 

Also added a `setTimeout` before `startScan` in the `ensureConnected` - not sure this is needed (I added it before I introduced the `ensureConnectedAndActive` wrapper as my first attempt to fix the infinite loop)

--- 
* I was not able to test the priming part yet (will need for the current patch to expire)
* but I did test the fix for the "infinite loop spinner" - it worked as expected, failing immediately when there was no active patch
* with an active patch - the loops are successful and the commands are confirmed successfully 