### PR TITLE
state sync and concurrency fixes

### DIFF
--- a/Common/DispatchGroup.swift
+++ b/Common/DispatchGroup.swift
@@ -13,12 +13,14 @@ final class MedtrumKitDispatchGroup {
     func leave() {
         lock.lock()
         count -= 1
-        guard count >= 0 else {
-            // Prevent crash on multiple leave calls
+        let isBalanced = count >= 0
+        lock.unlock()
+
+        // Prevent crash on multiple leave calls
+        guard isBalanced else {
             return
         }
 
-        lock.unlock()
         group.leave()
     }
 

--- a/Common/UnfinalizedDose.swift
+++ b/Common/UnfinalizedDose.swift
@@ -200,7 +200,7 @@ public class UnfinalizedDose {
         let startOfDay = Calendar.current.startOfDay(for: now)
         let nowTimeInterval = now.timeIntervalSince(startOfDay)
 
-        let currentRate = basalSchedule.entries.last(where: { $0.startTime < nowTimeInterval })?.rate ?? 0
+        let currentRate = basalSchedule.entries.last(where: { $0.startTime <= nowTimeInterval })?.rate ?? 0
         return UnfinalizedDose(
             basalRate: currentRate,
             insulinType: insulineType,

--- a/Common/UnfinalizedDose.swift
+++ b/Common/UnfinalizedDose.swift
@@ -159,7 +159,10 @@ public class UnfinalizedDose {
             )
 
         case .tempBasal:
-            let actualEndDate = isMutable ? estimatedEndDate : endDate
+            let actualEndDate = isMutable ?
+                estimatedEndDate :
+                min(endDate, estimatedEndDate) // in case this finalization happens late (TBR ended while not connected to the phone, etc)
+                                               // don't report the end date later than the scheduled end date
             let duration = actualEndDate.timeIntervalSince(startDate)
             return DoseEntry(
                 type: .tempBasal,

--- a/MedtrumKit/PumpManager/BluetoothManager.swift
+++ b/MedtrumKit/PumpManager/BluetoothManager.swift
@@ -13,8 +13,34 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
     private var forcedDisconnect: Bool = false
 
     var scanCompletion: ((MedtrumScanResult) -> Void)?
-    var connectCompletion: ((MedtrumConnectError?) -> Void)?
-    var connectionTimeout: Task<Void, Never>?
+
+    /// One connect attempt: the caller waiting on it, and the deadline that guarantees they hear
+    /// back. Connect, disconnect, timeout and the auth flow all race to report a result, so the
+    /// attempt owns which of them wins rather than each site checking for itself.
+    private final class ConnectAttempt {
+        let completion: (MedtrumConnectError?) -> Void
+        var timeout: Task<Void, Never>?
+        private var reported = false
+
+        init(_ completion: @escaping (MedtrumConnectError?) -> Void) {
+            self.completion = completion
+        }
+
+        /// True for the first caller only - whoever gets it owns reporting the result.
+        func claim() -> Bool {
+            guard !reported else {
+                return false
+            }
+
+            reported = true
+            timeout?.cancel()
+            timeout = nil
+
+            return true
+        }
+    }
+
+    private var attempt: ConnectAttempt?
 
     public var isConnected: Bool {
         if let peripheral = peripheral, peripheral.state == .connected {
@@ -69,44 +95,46 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
         manager.connect(peripheral)
     }
 
+    /// Reports `attempt`, if nobody has yet. Safe to call from anywhere, as often as you like.
+    private func finish(_ attempt: ConnectAttempt, _ error: MedtrumConnectError?) {
+        guard attempt.claim() else {
+            return
+        }
+
+        if self.attempt === attempt {
+            self.attempt = nil
+        }
+
+        // Never on the caller's thread. Completions issue blocking BLE writes: from the main thread
+        // that freezes the UI for up to 30s per packet (syncPumpTime sends three), and from
+        // managerQueue it would deadlock outright - that is the queue the response has to be
+        // delivered on. Today the managerQueue callers only ever report an error, and every
+        // completion returns early on error before writing, but nothing enforces that.
+        DispatchQueue.global(qos: .userInitiated).async {
+            attempt.completion(error)
+        }
+    }
+
     func ensureConnected(_ completion: @escaping (MedtrumConnectError?) -> Void) {
-        guard connectCompletion == nil else {
+        guard attempt == nil else {
             logger.error("EnsureConnected is already running...")
             completion(.failedToConnectToDevice)
             return
         }
 
-        var finished = false
-        connectCompletion = { (_ result: MedtrumConnectError?) -> Void in
-            guard !finished else {
-                return
-            }
-
-            finished = true
-            self.connectCompletion = nil
-            self.connectionTimeout?.cancel()
-            self.connectionTimeout = nil
-
-            // Never on the caller's thread. Completions issue blocking BLE writes: from the main
-            // thread that freezes the UI for up to 30s per packet (syncPumpTime sends three), and
-            // from managerQueue it would deadlock outright - that is the queue the response has to
-            // be delivered on. Today the managerQueue callers only ever report an error, and every
-            // completion returns early on error before writing, but nothing enforces that.
-            DispatchQueue.global(qos: .userInitiated).async {
-                completion(result)
-            }
-        }
+        let attempt = ConnectAttempt(completion)
+        self.attempt = attempt
 
         if let peripheral = peripheral, peripheral.state == .connected {
             logger.debug("Already connect!")
-            connectCompletion?(nil)
+            finish(attempt, nil)
             return
         }
 
         if let peripheral = peripheral {
             // We've the peripheral reference to a previous connection
             // Just try to reconnect
-            startTimeout(seconds: .seconds(15))
+            startTimeout(attempt, seconds: .seconds(15))
             connect(peripheral: peripheral)
             return
         }
@@ -114,14 +142,14 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
         let connectedDevices = manager.retrieveConnectedPeripherals(withServices: [CBUUID.SERVICE_UUID])
         if let peripheral = connectedDevices.first(where: { $0.name == "MT" }) {
             // Phone is already connected, but the app is not
-            startTimeout(seconds: .seconds(15))
+            startTimeout(attempt, seconds: .seconds(15))
             connect(peripheral: peripheral)
             return
         }
 
         guard var pumpSNState = pumpManager?.state.pumpSN else {
             logger.error("No pump serial number found")
-            connectCompletion?(.failedToFindDevice)
+            finish(attempt, .failedToFindDevice)
             return
         }
 
@@ -129,13 +157,17 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
 
         // We are disconnected and have no reference to the previous connection
         // Start to scan for patch and reconnect the long way
-        startTimeout(seconds: .seconds(15))
-        startScan { result in
+        startTimeout(attempt, seconds: .seconds(15))
+        startScan { [weak self] result in
+            guard let self else {
+                return
+            }
+
             switch result {
             case let .failure(error):
                 self.logger.error("Error during scanning: \(error.localizedDescription)")
                 self.manager.stopScan()
-                self.connectCompletion?(.failedToFindDevice)
+                self.finish(attempt, .failedToFindDevice)
 
             case let .success(peripheral, pumpSN, _, _):
                 guard pumpSN == pumpSNState else {
@@ -148,31 +180,35 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
         }
     }
 
-    func startTimeout(seconds: TimeInterval) {
-        connectionTimeout?.cancel()
+    private func startTimeout(_ attempt: ConnectAttempt, seconds: TimeInterval) {
+        attempt.timeout?.cancel()
 
-        connectionTimeout = Task {
+        attempt.timeout = Task { [weak self, weak attempt] in
             do {
                 try await Task.sleep(nanoseconds: UInt64(seconds) * 1_000_000_000)
-                guard let connectionCallback = self.connectCompletion else {
-                    // This is amazing, we've done what we must and continue our live :)
-                    return
-                }
+            } catch {
+                // Cancelled, because the attempt was reported before we woke
+                return
+            }
 
-                // Don't skip this just because the peripheral is connected by now: the link coming
-                // up is not the same as being ready, since auth, synchronize and subscribe still
-                // follow. Skipping would leave connectCompletion set with nothing to clear it,
-                // wedging every later ensureConnected. didConnect re-arms us on a longer budget.
-                self.logger.error("Failed to connect: Timeout reached...")
+            // The one condition that matters: is this still the attempt in flight? Covers being
+            // superseded by a re-arm, and waking a moment before cancellation landed.
+            guard let self, let attempt, self.attempt === attempt else {
+                return
+            }
 
-                if self.manager.isScanning {
-                    self.manager.stopScan()
-                    self.scanCompletion = nil
-                }
+            // Don't skip this just because the peripheral is connected by now: the link coming up
+            // is not the same as being ready, since auth, synchronize and subscribe still follow.
+            // Skipping would leave the attempt in flight with nothing to clear it, wedging every
+            // later ensureConnected. didConnect re-arms us on a longer budget.
+            self.logger.error("Failed to connect: Timeout reached...")
 
-                connectionCallback(.failedToConnectToDevice)
-                self.connectCompletion = nil
-            } catch {}
+            if self.manager.isScanning {
+                self.manager.stopScan()
+                self.scanCompletion = nil
+            }
+
+            self.finish(attempt, .failedToConnectToDevice)
         }
     }
 
@@ -210,28 +246,28 @@ extension BluetoothManager {
             return
         }
 
-        guard connectCompletion == nil else {
-            // Somebody is already connecting and owns the completion. Installing ours over it would
-            // strand that caller - it would never be called back at all.
+        guard attempt == nil else {
+            // Somebody is already connecting and owns the attempt. Installing ours over it would
+            // strand that caller - they would never be called back at all.
             logger.info("Powered on while a connect attempt is in flight, leaving it be")
             return
         }
 
         if let peripheral = self.peripheral {
             logger.info("Reconnecting to restored state...")
-            connectCompletion = { (error: MedtrumConnectError?) -> Void in
-                if let error = error {
-                    self.logger.error("Failed to restore state: \(error)")
-                } else {
-                    self.logger.info("Restored state!")
-                }
 
-                self.connectCompletion = nil
+            let attempt = ConnectAttempt { [weak self] (error: MedtrumConnectError?) in
+                if let error = error {
+                    self?.logger.error("Failed to restore state: \(error)")
+                } else {
+                    self?.logger.info("Restored state!")
+                }
             }
+            self.attempt = attempt
 
             // Without this the restore path has no deadline at all: a connect that never completes
-            // leaves connectCompletion set for good, and every later ensureConnected fails.
-            startTimeout(seconds: .seconds(15))
+            // leaves the attempt in flight for good, and every later ensureConnected fails.
+            startTimeout(attempt, seconds: .seconds(15))
             connect(peripheral: peripheral)
             return
         }
@@ -308,7 +344,7 @@ extension BluetoothManager {
 
         // The attempt this belongs to already gave up - typically its timeout fired while the pump
         // was out of range, and it only came back now.
-        guard let completion = connectCompletion else {
+        guard let attempt = attempt else {
             logger.warning("No connectCompletion...")
             disconnect(force: true)
             return
@@ -317,12 +353,14 @@ extension BluetoothManager {
         forcedDisconnect = false
 
         self.peripheral = peripheral
-        peripheralManager = PeripheralManager(peripheral, self, pumpManager, completion)
+        peripheralManager = PeripheralManager(peripheral, self, pumpManager) { [weak self] error in
+            self?.finish(attempt, error)
+        }
 
         // The link is up but the flow is not done - auth, synchronize and subscribe still have to
         // run, and each of those is a writePacket with its own 30s timeout. Re-arm on a budget that
         // covers all of them, so a stalled flow still reports back instead of hanging the caller.
-        startTimeout(seconds: .seconds(150))
+        startTimeout(attempt, seconds: .seconds(150))
 
         peripheral.discoverServices([CBUUID.SERVICE_UUID])
     }
@@ -364,9 +402,8 @@ extension BluetoothManager {
             self.peripheralManager = nil
         }
 
-        if let connectCompletion = connectCompletion {
-            connectCompletion(.failedToConnectToDevice)
-            self.connectCompletion = nil
+        if let attempt = attempt {
+            finish(attempt, .failedToConnectToDevice)
 
         } else {
             ensureConnected { error in
@@ -390,6 +427,8 @@ extension BluetoothManager {
 
         // The attempt is over, so report it now. Leaving it to the timeout means the caller waits
         // out the full budget for a failure we already know about.
-        connectCompletion?(.failedToConnectToDevice)
+        if let attempt = attempt {
+            finish(attempt, .failedToConnectToDevice)
+        }
     }
 }

--- a/MedtrumKit/PumpManager/BluetoothManager.swift
+++ b/MedtrumKit/PumpManager/BluetoothManager.swift
@@ -46,7 +46,7 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
             return
         }
 
-        if !manager.isScanning {
+        if manager.isScanning {
             manager.stopScan()
         }
 

--- a/MedtrumKit/PumpManager/BluetoothManager.swift
+++ b/MedtrumKit/PumpManager/BluetoothManager.swift
@@ -149,6 +149,8 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
     }
 
     func startTimeout(seconds: TimeInterval) {
+        connectionTimeout?.cancel()
+
         connectionTimeout = Task {
             do {
                 try await Task.sleep(nanoseconds: UInt64(seconds) * 1_000_000_000)
@@ -157,11 +159,10 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
                     return
                 }
 
-                if let peripheral = self.peripheral, peripheral.state == .connected {
-                    // This is amazing, we've done what we must and continue our live :)
-                    return
-                }
-
+                // Don't skip this just because the peripheral is connected by now: the link coming
+                // up is not the same as being ready, since auth, synchronize and subscribe still
+                // follow. Skipping would leave connectCompletion set with nothing to clear it,
+                // wedging every later ensureConnected. didConnect re-arms us on a longer budget.
                 self.logger.error("Failed to connect: Timeout reached...")
 
                 if self.manager.isScanning {
@@ -209,6 +210,13 @@ extension BluetoothManager {
             return
         }
 
+        guard connectCompletion == nil else {
+            // Somebody is already connecting and owns the completion. Installing ours over it would
+            // strand that caller - it would never be called back at all.
+            logger.info("Powered on while a connect attempt is in flight, leaving it be")
+            return
+        }
+
         if let peripheral = self.peripheral {
             logger.info("Reconnecting to restored state...")
             connectCompletion = { (error: MedtrumConnectError?) -> Void in
@@ -221,6 +229,9 @@ extension BluetoothManager {
                 self.connectCompletion = nil
             }
 
+            // Without this the restore path has no deadline at all: a connect that never completes
+            // leaves connectCompletion set for good, and every later ensureConnected fails.
+            startTimeout(seconds: .seconds(15))
             connect(peripheral: peripheral)
             return
         }
@@ -285,20 +296,34 @@ extension BluetoothManager {
     func centralManager(_: CBCentralManager, didConnect peripheral: CBPeripheral) {
         logger.info("Connected to pump: \(peripheral.name ?? "<NO_NAME>")!")
 
+        // Both guards below drop the link rather than just returning. `peripheral` is already set at
+        // this point, so bailing out would leave a live peripheral with no PeripheralManager behind
+        // it: the next ensureConnected reports "Already connect!" while every write fails with
+        // .noManager, and nothing clears that until the link happens to drop on its own.
         guard let pumpManager = pumpManager else {
             logger.warning("No pumpManager...")
-            return
-        }
-        guard let completion = connectCompletion else {
-            logger.warning("No connectCompletion...")
+            disconnect(force: true)
             return
         }
 
-        connectionTimeout?.cancel()
+        // The attempt this belongs to already gave up - typically its timeout fired while the pump
+        // was out of range, and it only came back now.
+        guard let completion = connectCompletion else {
+            logger.warning("No connectCompletion...")
+            disconnect(force: true)
+            return
+        }
+
         forcedDisconnect = false
 
         self.peripheral = peripheral
         peripheralManager = PeripheralManager(peripheral, self, pumpManager, completion)
+
+        // The link is up but the flow is not done - auth, synchronize and subscribe still have to
+        // run, and each of those is a writePacket with its own 30s timeout. Re-arm on a budget that
+        // covers all of them, so a stalled flow still reports back instead of hanging the caller.
+        startTimeout(seconds: .seconds(150))
+
         peripheral.discoverServices([CBUUID.SERVICE_UUID])
     }
 
@@ -358,11 +383,13 @@ extension BluetoothManager {
                 "Device connect error, name: \(peripheral.name ?? "<NO_NAME>"), error: \(error?.localizedDescription ?? "No error")"
             )
 
-        guard let pumpManager = self.pumpManager else {
-            return
+        if let pumpManager = self.pumpManager {
+            pumpManager.state.isConnected = false
+            pumpManager.notifyStateDidChange()
         }
 
-        pumpManager.state.isConnected = false
-        pumpManager.notifyStateDidChange()
+        // The attempt is over, so report it now. Leaving it to the timeout means the caller waits
+        // out the full budget for a failure we already know about.
+        connectCompletion?(.failedToConnectToDevice)
     }
 }

--- a/MedtrumKit/PumpManager/BluetoothManager.swift
+++ b/MedtrumKit/PumpManager/BluetoothManager.swift
@@ -86,7 +86,15 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
             self.connectCompletion = nil
             self.connectionTimeout?.cancel()
             self.connectionTimeout = nil
-            completion(result)
+
+            // Never on the caller's thread. Completions issue blocking BLE writes: from the main
+            // thread that freezes the UI for up to 30s per packet (syncPumpTime sends three), and
+            // from managerQueue it would deadlock outright - that is the queue the response has to
+            // be delivered on. Today the managerQueue callers only ever report an error, and every
+            // completion returns early on error before writing, but nothing enforces that.
+            DispatchQueue.global(qos: .userInitiated).async {
+                completion(result)
+            }
         }
 
         if let peripheral = peripheral, peripheral.state == .connected {

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -328,20 +328,20 @@ public extension MedtrumPumpManager {
 
     private func resetBolusState() {
         state.bolusDose = nil
-        state.isCancelingBolus = false
+        state.cancelingBolusSince = nil
         notifyStateDidChange()
     }
 
     func cancelBolus(completion: @escaping (LoopKit.PumpManagerResult<LoopKit.DoseEntry?>) -> Void) {
         log.info("Cancelling bolus...")
 
-        state.isCancelingBolus = true
+        state.cancelingBolusSince = Date.now
         notifyStateDidChange()
 
         ensureConnectedAndActive { error in
             if let error = error {
                 self.log.error("Failed to connect: \(error.localizedDescription)")
-                self.state.isCancelingBolus = false
+                self.state.cancelingBolusSince = nil
                 self.notifyStateDidChange()
 
                 completion(.failure(.communication(error)))
@@ -351,7 +351,7 @@ public extension MedtrumPumpManager {
             let result = self.bluetooth.write(CancelBolusPacket())
             if case let .failure(error) = result {
                 self.log.error("Failed to cancel bolus: \(error.localizedDescription)")
-                self.state.isCancelingBolus = false
+                self.state.cancelingBolusSince = nil
                 self.notifyStateDidChange()
 
                 completion(.failure(.communication(error)))
@@ -361,7 +361,7 @@ public extension MedtrumPumpManager {
             self.log.info("Bolus cancelled!")
 
             guard let doseEntry = self.state.bolusDose else {
-                self.state.isCancelingBolus = false
+                self.state.cancelingBolusSince = nil
                 self.notifyStateDidChange()
 
                 completion(.success(nil))
@@ -379,7 +379,7 @@ public extension MedtrumPumpManager {
             )
 
             self.state.bolusDose = nil
-            self.state.isCancelingBolus = false
+            self.state.cancelingBolusSince = nil
             self.state.lastSync = Date.now
             self.notifyStateDidChange()
 

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -320,7 +320,6 @@ public extension MedtrumPumpManager {
             self.emitPumpEvents(events, replacePendingEvents: false)
 
             self.state.bolusDose = doseEntry
-            self.state.bolusState = .inProgress
             self.notifyStateDidChange()
 
             completion(nil)
@@ -328,22 +327,21 @@ public extension MedtrumPumpManager {
     }
 
     private func resetBolusState() {
-        state.bolusState = .noBolus
         state.bolusDose = nil
+        state.isCancelingBolus = false
         notifyStateDidChange()
     }
 
     func cancelBolus(completion: @escaping (LoopKit.PumpManagerResult<LoopKit.DoseEntry?>) -> Void) {
         log.info("Cancelling bolus...")
 
-        let oldBolusState = state.bolusState
-        state.bolusState = .canceling
+        state.isCancelingBolus = true
         notifyStateDidChange()
 
         ensureConnectedAndActive { error in
             if let error = error {
                 self.log.error("Failed to connect: \(error.localizedDescription)")
-                self.state.bolusState = oldBolusState
+                self.state.isCancelingBolus = false
                 self.notifyStateDidChange()
 
                 completion(.failure(.communication(error)))
@@ -353,7 +351,7 @@ public extension MedtrumPumpManager {
             let result = self.bluetooth.write(CancelBolusPacket())
             if case let .failure(error) = result {
                 self.log.error("Failed to cancel bolus: \(error.localizedDescription)")
-                self.state.bolusState = oldBolusState
+                self.state.isCancelingBolus = false
                 self.notifyStateDidChange()
 
                 completion(.failure(.communication(error)))
@@ -361,10 +359,11 @@ public extension MedtrumPumpManager {
             }
 
             self.log.info("Bolus cancelled!")
-            self.state.bolusState = .noBolus
-            self.notifyStateDidChange()
 
             guard let doseEntry = self.state.bolusDose else {
+                self.state.isCancelingBolus = false
+                self.notifyStateDidChange()
+
                 completion(.success(nil))
                 return
             }
@@ -380,6 +379,7 @@ public extension MedtrumPumpManager {
             )
 
             self.state.bolusDose = nil
+            self.state.isCancelingBolus = false
             self.state.lastSync = Date.now
             self.notifyStateDidChange()
 
@@ -949,7 +949,6 @@ public extension MedtrumPumpManager {
             )
         )
 
-        state.bolusState = .noBolus
         state.bolusDose = nil
         state.lastSync = Date.now
         notifyStateDidChange()
@@ -1005,7 +1004,6 @@ public extension MedtrumPumpManager {
             )
         )
 
-        state.bolusState = .noBolus
         state.lastSync = Date.now
         state.bolusDose = nil
         notifyStateDidChange()

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -427,38 +427,14 @@ public extension MedtrumPumpManager {
                     return
                 }
 
+                self.state.basalState = .active
                 self.log.info("Cancelled temp basal!")
             }
 
             if duration < .ulpOfOne {
                 // Need to cancel temp basal, but is already cancelled
                 // Only need to report back to algorithm
-                let now = Date.now
-                var events = self.getActivePumpEvents(endDate: now)
-
-                // Maybe the temp basal already expired
-                // So only add the basal event if it isn't already in the list
-                if !events.contains(where: { $0.type == .basal }) {
-                    let basalDose = UnfinalizedDose(
-                        basalRate: self.state.currentBaseBasalRate,
-                        insulinType: self.state.insulinType,
-                        startDate: now
-                    )
-
-                    events.append(
-                        NewPumpEvent.basal(
-                            dose: basalDose.toDoseEntry(),
-                            date: now
-                        )
-                    )
-
-                    self.state.basalDose = basalDose
-                }
-
-                self.state.lastSync = Date.now
-                self.notifyStateDidChange()
-
-                self.emitPumpEvents(events)
+                self.reportScheduledBasal()
 
                 completion(nil)
                 return
@@ -469,6 +445,10 @@ public extension MedtrumPumpManager {
 
             if case let .failure(error) = tempBasalResult {
                 self.log.error("Failed to set temp basal: \(error.localizedDescription)")
+
+                // the cancel already succeeded, but new TBR failed - the patch is running the scheduled basal now
+                self.reportScheduledBasal()
+
                 completion(.communication(error))
                 return
             }
@@ -490,6 +470,7 @@ public extension MedtrumPumpManager {
             )
 
             self.state.basalDose = tempBasalDose
+            self.state.basalState = .tempBasal
             self.state.lastSync = Date.now
             self.notifyStateDidChange()
 
@@ -497,6 +478,35 @@ public extension MedtrumPumpManager {
 
             completion(nil)
         }
+    }
+
+    private func reportScheduledBasal() {
+        let now = Date.now
+        var events = getActivePumpEvents(endDate: now)
+
+        // Maybe the temp basal already expired
+        // So only add the basal event if it isn't already in the list
+        if !events.contains(where: { $0.type == .basal }) {
+            let basalDose = UnfinalizedDose(
+                basalRate: state.currentBaseBasalRate,
+                insulinType: state.insulinType,
+                startDate: now
+            )
+
+            events.append(
+                NewPumpEvent.basal(
+                    dose: basalDose.toDoseEntry(),
+                    date: now
+                )
+            )
+
+            state.basalDose = basalDose
+        }
+
+        state.lastSync = Date.now
+        notifyStateDidChange()
+
+        emitPumpEvents(events)
     }
 
     func suspendDelivery(completion: @escaping ((any Error)?) -> Void) {

--- a/MedtrumKit/PumpManager/MedtrumPumpState.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpState.swift
@@ -105,12 +105,6 @@ public class MedtrumPumpState: RawRepresentable {
             basalState = .active
         }
 
-        if let bolusStateRaw = rawValue["bolusState"] as? BolusState.RawValue {
-            bolusState = BolusState(rawValue: bolusStateRaw) ?? .noBolus
-        } else {
-            bolusState = .noBolus
-        }
-
         if let alarmSettingRaw = rawValue["alarmSetting"] as? AlarmSettings.RawValue {
             alarmSetting = AlarmSettings(rawValue: alarmSettingRaw) ?? .BeepOnly
         } else {
@@ -152,7 +146,6 @@ public class MedtrumPumpState: RawRepresentable {
         reservoir = 0
         battery = 0
         basalState = .active
-        bolusState = .noBolus
         alarmSetting = .BeepOnly
         expiryMode = .default
         notificationAfterActivation = .hours(72)
@@ -189,7 +182,6 @@ public class MedtrumPumpState: RawRepresentable {
         value["maxHourlyInsulin"] = maxHourlyInsulin
         value["maxDailyInsulin"] = maxDailyInsulin
         value["basalSchedule"] = basalSchedule.rawValue
-        value["bolusState"] = bolusState.rawValue
         value["initialReservoir"] = initialReservoir
         value["bolusDose"] = bolusDose?.rawValue
         value["basalDose"] = basalDose.rawValue
@@ -259,10 +251,19 @@ public class MedtrumPumpState: RawRepresentable {
     // **** THESE VALUES SHOULD NOT BE PERSISTED ****
     public var primeProgress: UInt8 = 0
     public var isConnected: Bool = false
+    // if it was persisted, and we happen to restore `true` - there will be nothing left to reset it to `false`
+    public var isCancelingBolus: Bool = false
     // **** END ****
 
-    public var bolusState: BolusState
     public var bolusDose: UnfinalizedDose?
+
+    public var bolusState: BolusState {
+        if isCancelingBolus {
+            return .canceling
+        }
+
+        return bolusDose == nil ? .noBolus : .inProgress
+    }
 
     // basalState is the basalState from the patch itself
     // Preventing acting on an out-dated basalDose
@@ -284,18 +285,15 @@ public class MedtrumPumpState: RawRepresentable {
     }
 
     var bolusDeliveryState: PumpManagerStatus.BolusState {
-        switch bolusState {
-        case .noBolus:
-            return .noBolus
-        case .canceling:
+        if isCancelingBolus {
             return .canceling
-        case .inProgress:
-            if let dose = bolusDose?.toDoseEntry(isMutable: true) {
-                return .inProgress(dose)
-            }
+        }
 
+        guard let dose = bolusDose?.toDoseEntry(isMutable: true) else {
             return .noBolus
         }
+
+        return .inProgress(dose)
     }
 
     public var currentBaseBasalRate: Double {

--- a/MedtrumKit/PumpManager/MedtrumPumpState.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpState.swift
@@ -248,14 +248,28 @@ public class MedtrumPumpState: RawRepresentable {
     public var expiryMode: ExpiryMode
     public var notificationAfterActivation: TimeInterval
 
+    /// Resetting "cancelingBolusSince" to nil depends on `ensureConnected` calling the callback.
+    /// `ensureConnected` orphans its completion in a few places.
+    /// So instead of a boolean, we use a date, which "auto-expires" after this timeout.
+    /// This timeout is longer than the 30s write timeout plus a reconnect.
+    private static let cancelBolusTimeout: TimeInterval = .minutes(2)
+
     // **** THESE VALUES SHOULD NOT BE PERSISTED ****
     public var primeProgress: UInt8 = 0
     public var isConnected: Bool = false
-    // if it was persisted, and we happen to restore `true` - there will be nothing left to reset it to `false`
-    public var isCancelingBolus: Bool = false
+    // if it was persisted, and we happen to restore a date - there will be nothing left to reset it to `nil`
+    public var cancelingBolusSince: Date?
     // **** END ****
 
     public var bolusDose: UnfinalizedDose?
+
+    private var isCancelingBolus: Bool {
+        guard let since = cancelingBolusSince else {
+            return false
+        }
+
+        return Date.now.timeIntervalSince(since) < MedtrumPumpState.cancelBolusTimeout
+    }
 
     public var bolusState: BolusState {
         if isCancelingBolus {

--- a/MedtrumKit/PumpManager/MedtrumPumpState.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpState.swift
@@ -303,7 +303,7 @@ public class MedtrumPumpState: RawRepresentable {
         let startOfDay = Calendar.current.startOfDay(for: now)
         let nowTimeInterval = now.timeIntervalSince(startOfDay)
 
-        return basalSchedule.entries.last(where: { $0.startTime < nowTimeInterval })?.rate ?? 0
+        return basalSchedule.entries.last(where: { $0.startTime <= nowTimeInterval })?.rate ?? 0
     }
 
     public var model: String {

--- a/MedtrumKit/PumpManager/PeripheralManager.swift
+++ b/MedtrumKit/PumpManager/PeripheralManager.swift
@@ -2,7 +2,6 @@ import CoreBluetooth
 
 class PeripheralManager: NSObject {
     private let log = MedtrumLogger(category: "PeripheralManager")
-    private let queue = DispatchQueue(label: "org.nightscout.MedtrumKit.message-queue")
 
     private let peripheral: CBPeripheral
     private let bluetoothManager: BluetoothManager
@@ -12,11 +11,21 @@ class PeripheralManager: NSObject {
     private var readCharacteristic: CBCharacteristic?
     private var writeCharacteristic: CBCharacteristic?
 
+    // access is serialized by the semaphore inside writePacket
     private var writeSequence: UInt8 = 0
-    private var currentPacket: (any MedtrumBasePacketProtocol)?
 
+    /// Guards the four fields below. writePacket runs on the caller's thread while the response
+    /// arrives on the central manager's queue, so every access to them is cross-thread. Never
+    /// held across `writeQ.wait()`, `peripheral.writeValue` or `leave()`.
+    private let stateLock = NSLock()
+
+    /* access must be serialized with stateLock */
+    private var currentPacket: (any MedtrumBasePacketProtocol)?
+    private var currentSequence: UInt8 = 0
     private var writeQueue: MedtrumKitDispatchGroup?
     private var writeResponse: MedtrumWriteResult<Any>?
+    /* end */
+
     private let semaphore = DispatchSemaphore(value: 1)
 
     public init(
@@ -36,10 +45,15 @@ class PeripheralManager: NSObject {
     }
 
     func cleanup() {
-        if let queue = writeQueue {
-            queue.leave()
-            writeQueue = nil
-        }
+        stateLock.lock()
+        let queue = writeQueue
+        writeQueue = nil
+        currentPacket = nil
+        stateLock.unlock()
+
+        // outside the lock: leave() takes a lock of its own, and it wakes writePacket, which
+        // immediately wants ours.
+        queue?.leave()
     }
 
     func writePacket(_ packet: any MedtrumBasePacketProtocol) -> MedtrumWriteResult<Any> {
@@ -55,8 +69,12 @@ class PeripheralManager: NSObject {
 
         let writeQ = MedtrumKitDispatchGroup()
         writeQ.enter()
+
+        stateLock.lock()
         writeQueue = writeQ
         currentPacket = packet
+        currentSequence = writeSequence
+        stateLock.unlock()
 
         let packages = packet.encode(sequenceNumber: writeSequence)
         writeSequence = UInt8(writeSequence + 1)
@@ -71,14 +89,21 @@ class PeripheralManager: NSObject {
 
         // Wait for response or timeout timer...
         _ = writeQ.wait(timeout: .now() + .seconds(30))
-        writeQueue = nil
 
-        guard let response = writeResponse else {
+        // Tear down as one step: on timeout the delegate may still be mid-flight, and this is
+        // what tells it the command is no longer current.
+        stateLock.lock()
+        let response = writeResponse
+        writeQueue = nil
+        currentPacket = nil
+        writeResponse = nil
+        stateLock.unlock()
+
+        guard let response = response else {
             log.warning("Timeout has been reached...")
             return .failure(error: .timeout)
         }
 
-        writeResponse = nil
         return response
     }
 }
@@ -261,22 +286,42 @@ extension PeripheralManager: CBPeripheralDelegate {
 
         // Processing data
         log.debug("Got data: \(data.hexEncodedString())")
-        guard var packet = currentPacket else {
+
+        stateLock.lock()
+        let sequence = currentSequence
+        let pending = currentPacket
+        stateLock.unlock()
+
+        guard var packet = pending else {
             log.warning("No packet available...")
             return
         }
 
-        packet.decode(data)
-        currentPacket = packet
-
-        guard packet.isComplete else {
-            log.debug("Waiting for more data...")
+        // Byte 2 echoes the sequence number of the command this is a response to, on every
+        // fragment. It has to be checked on all of them, not just the first: decode() validates
+        // a continuation fragment for ordering and CRC only, so a late fragment of an abandoned
+        // command would otherwise be appended to whatever packet is now in flight - with a valid
+        // CRC and a matching fragment index, so nothing downstream would notice.
+        if data.count > 2, data[2] != sequence {
+            log.warning("Ignoring response for sequence \(data[2]), waiting on \(sequence)")
             return
         }
 
-        guard let writeCallback = writeQueue else {
-            // Timeout is hit...
-            currentPacket = nil
+        packet.decode(data)
+
+        stateLock.lock()
+        guard currentSequence == sequence, writeQueue != nil else {
+            // writePacket timed out while we were decoding, and may already have started
+            // another command. This response is no longer anybody's.
+            stateLock.unlock()
+            log.warning("Discarding response for sequence \(sequence), no longer the current command")
+            return
+        }
+        currentPacket = packet
+        stateLock.unlock()
+
+        guard packet.isComplete else {
+            log.debug("Waiting for more data...")
             return
         }
 
@@ -286,30 +331,38 @@ extension PeripheralManager: CBPeripheralDelegate {
             return
         }
 
+        let response: MedtrumWriteResult<Any>
         if packet.responseCode != 0 {
             // Examples for invalid codes:
             // 7 -> Invalid authorization: propably wrong session token used
             // 8 -> Invalid state: The patch is not in state 32 (active), which is required for that command
             log.error("Invalid responseCode: \(packet.responseCode)")
-            writeResponse = .failure(error: .invalidResponse(code: packet.responseCode))
+            response = .failure(error: .invalidResponse(code: packet.responseCode))
         } else if packet.failed {
             log.error("Failed to parse message, either wrong command type or CRC check failed...")
-            writeResponse = .failure(error: .invalidData)
-        } else {
-            if !packet.hasEnoughData {
-                let message =
-                    "Packet has too little data - expected: \(packet.mimimumDataSize), data: \(packet.totalData.hexEncodedString())"
-                log.error(message)
+            response = .failure(error: .invalidData)
+        } else if !packet.hasEnoughData {
+            let message =
+                "Packet has too little data - expected: \(packet.mimimumDataSize), data: \(packet.totalData.hexEncodedString())"
+            log.error(message)
 
-                writeResponse = .failure(error: .invalidData)
-            } else {
-                writeResponse = .success(data: packet.parseResponse())
-            }
+            response = .failure(error: .invalidData)
+        } else {
+            response = .success(data: packet.parseResponse())
         }
 
-        writeCallback.leave()
+        stateLock.lock()
+        guard currentSequence == sequence, let writeCallback = writeQueue else {
+            // Timed out between decoding and parsing; writePacket has already given up
+            stateLock.unlock()
+            return
+        }
+        writeResponse = response
         writeQueue = nil
         currentPacket = nil
+        stateLock.unlock()
+
+        // Outside the lock, and last: this hands writePacket the fields we just finished with.
         writeCallback.leave()
     }
 

--- a/MedtrumKit/PumpManager/PeripheralManager.swift
+++ b/MedtrumKit/PumpManager/PeripheralManager.swift
@@ -310,6 +310,7 @@ extension PeripheralManager: CBPeripheralDelegate {
         writeCallback.leave()
         writeQueue = nil
         currentPacket = nil
+        writeCallback.leave()
     }
 
     private func handleHeartbeat(data: Data) {

--- a/MedtrumKit/PumpManager/PeripheralManager.swift
+++ b/MedtrumKit/PumpManager/PeripheralManager.swift
@@ -152,7 +152,7 @@ extension PeripheralManager {
         case .success:
             log.info("Connected to pump!")
 
-            pumpManager.state.isConnected = false
+            pumpManager.state.isConnected = true
             pumpManager.notifyStateDidChange()
             completion?(nil)
         }

--- a/MedtrumKit/PumpManager/StateSyncer.swift
+++ b/MedtrumKit/PumpManager/StateSyncer.swift
@@ -135,11 +135,8 @@ enum StateSyncer {
                 completed: bolusProgress.completed,
                 useEstimatedEndDate: duringReconnect
             )
-            pumpManager.state.bolusState = bolusProgress.completed ? .noBolus : .inProgress
         } else if duringReconnect {
             pumpManager.checkBolusDone()
-        } else {
-            pumpManager.state.bolusState = .noBolus
         }
 
         pumpManager.notifyStateDidChange()


### PR DESCRIPTION
## Overview

This PR had one motivating problem behind it:
* a segfault from 2026-07-23 that I had

which led to me committing to a deeper research (using Claude) and ending up with a series of commits,
attempting to fix several different issues in how driver state is kept in sync and how BLE access is serialised.

### How to not to get lost in the diff :)

* looking commit-by-commit will be much easier
  - 45ff24888d71284326551301e6df1158244dd5f1 - the crash, 3d70c8d27cee5ed1ccb7f8fb8d950c9d3e82a262 - the skipped loops, these two were "driven" by the crash report and from the logs
* several commits rewrite code that earlier ones in the PR just touched
  - c01f016fcb131e6ffd83cdad8a3c0cc91bcc3903, 878930774936359d9e092361e8e4091a7ce8f916, 6bdbf4413330339bdfb9464f664f4b1487f7a323, 5da7babe31d6410c99fda999717c1da0a8e67e49, c20a664e5e2037f0ebfbd0a11a929e8a3749bc59: small and independent, one file each
  - 3d70c8d27cee5ed1ccb7f8fb8d950c9d3e82a262 → 01e03c21cf564a7c52801782f783e54e2d70eb8c: state model; the second commit changes a field the first one adds
  - 45ff24888d71284326551301e6df1158244dd5f1 → 51847ec20a0b177a8ccf11e605ca56251cf6a591: the crash fix, then the locking around it
  - 265b603701ab792b34c61b23d848ead8aefd65d7 → 3dd8ecff447fcbb4c9d28e4bcd428cfe527d0d33 → 75528760208a2c0a9365ebe4d2bfc1744c2953ae: BluetoothManager; the last commit restructures the code from the first two

### issues investigated from the logs and the crash report

* **The crash** (reproduced from crash reports and logs)
  * A double-release crash in `PeripheralManager.writePacket` (45ff24888d71284326551301e6df1158244dd5f1)

* **skipped loops** - caused by a stale sync response leaving `bolusState` stuck until subsequent re-sync (3d70c8d27cee5ed1ccb7f8fb8d950c9d3e82a262)

### Other changes

**Everything else is pro-active** - real (as far as I can tell) defects found by inspection, but not observed in the logs.

---

All changes are split into relatively small self-contained commits.
Most of the commits have a more detailed message describing the change, below are just summaries, in chronological order.

---

### c01f016fcb131e6ffd83cdad8a3c0cc91bcc3903 TBR end date - never report longer than requested

`toDoseEntry` never clamped `endDate` to `estimatedEndDate` - if finalization happened *after* the TBR would have expired (no connection, etc) - the TBR duration would have been reported incorrectly (until `now`)

### 878930774936359d9e092361e8e4091a7ce8f916 Schedule lookup at exact boundaries

`<` → `<=` when looking up the basal schedule, minor

### 6bdbf4413330339bdfb9464f664f4b1487f7a323 Two inverted booleans

`if !manager.isScanning { stopScan() }` (the other two call sites have it right), and
`isConnected = false` on *successful* subscribe.

### 5da7babe31d6410c99fda999717c1da0a8e67e49 Temp basal state tracking

`enactTempBasal` never set `state.basalState`, relying on the next sync. So a cancel request could
skip the cancel packet on a stale flag, leaving a TBR running while reporting scheduled basal, and
a cancel-succeeded/set-failed sequence left the old TBR as a pending dose.

### 3d70c8d27cee5ed1ccb7f8fb8d950c9d3e82a262 `bolusState` derived from `bolusDose`

(one lost loop cycle in the logs due to this)

```
01:41:10  Enact bolus - 2.0U
01:42:29  bolus completed:true delivered:2            <- finalised, bolusDose = nil
01:42:36  Manual sync: completed:false delivered:1.9  <- stale, requested at 01:42:26
01:42:37  ERROR: Pump is in bolus state
01:42:37  [iAPS] Loop failed: Bolus issue. Patch is already bolussing
```

A 10-second-old in-flight response resurrected `.inProgress` after the dose was gone.

### c20a664e5e2037f0ebfbd0a11a929e8a3749bc59 DispatchGroup — don't hold the lock on double-leave

(same fix as in DanaKit)

### 45ff24888d71284326551301e6df1158244dd5f1 `writeCallback.leave()` last

This was the cause of the crash.
`FreeAPS-2026-07-23-031332.ips` — `EXC_BAD_ACCESS` in `swift_release_dealloc`, thread 7,
`PeripheralManager.writePacket`. `leave()` released the waiter *before* the delegate finished
clearing `writeQueue`, so both threads nil'd it: two releases, one retain. Log matches to the second
(`03:13:30` write, `03:13:31` response, `03:13:32` crash).

### 51847ec20a0b177a8ccf11e605ca56251cf6a591 Sequence matching + locked cross-thread state

Two parts. The locking covers the paths `leave()` ordering can't order — the 30 s timeout and
`cleanup()` on disconnect — same defect class as the crash. The sequence check rejects a response
whose echoed command sequence doesn't match the one in flight, on every fragment: `decode` validates
a continuation fragment for ordering and CRC only, so a late fragment of an abandoned command would
otherwise append to the current packet with a valid CRC and matching index, and nothing downstream
would notice.

### 01e03c21cf564a7c52801782f783e54e2d70eb8c Auto-clear `.canceling` after 60 s

`cancelBolus` clears its flag only from its own completion, which can be stranded. A stuck
`.canceling` rejects every command until app restart.

### 265b603701ab792b34c61b23d848ead8aefd65d7 Never run a connect completion on the caller's thread

Completions issue blocking BLE writes. `syncPumpTime()` runs on main, `ensureConnected` completed
synchronously on the "Already connect!" path — the common one — and `StateSyncer.syncTime` then sends
three packets at 30 s each. Up to 90 s of frozen UI. The deadlock half is prophylactic: DanaKit hit
exactly that (`1d4f890`).

(inspired by @bastiaanv's fix in the DanaKit - https://github.com/bastiaanv/DanaKit/pull/49/changes/1d4f890c88d2aba49100617f8c560374f4f275f5)

### 3dd8ecff447fcbb4c9d28e4bcd428cfe527d0d33 Connect timeout management and 75528760208a2c0a9365ebe4d2bfc1744c2953ae `ConnectAttempt` helper

Trying to eliminate some of the potential race conditions and mis-behaviors in the `BluetoothManager`.

---

## Known gaps/potential improvements, maybe for the future

- `BluetoothManager`'s shared state is still unsynchronised
- `ensureConnected` should probably hand the `PeripheralManager` to its completion rather than callers looking it up
- AndroidAPS implements `GET_RECORD` to get the real TBR start/end times and delivered amounts, we could do the same